### PR TITLE
perform: GoogleFontに変更

### DIFF
--- a/workspaces/server/index.html
+++ b/workspaces/server/index.html
@@ -10,15 +10,9 @@
       type="image/x-icon"
     />
     <title>WSH 2024</title>
-    <link rel="preload" crossorigin="anonymous" href="/assets/NotoSansJP-Black.woff" as="font" type="font/woff" />
-    <link rel="preload" crossorigin="anonymous" href="/assets/NotoSansJP-Bold.woff" as="font" type="font/woff" />
-    <link rel="preload" crossorigin="anonymous" href="/assets/NotoSansJP-ExtraBold.woff" as="font" type="font/woff" />
-    <link rel="preload" crossorigin="anonymous" href="/assets/NotoSansJP-ExtraLight.woff" as="font" type="font/woff" />
-    <link rel="preload" crossorigin="anonymous" href="/assets/NotoSansJP-Light.woff" as="font" type="font/woff" />
-    <link rel="preload" crossorigin="anonymous" href="/assets/NotoSansJP-Medium.woff" as="font" type="font/woff" />
-    <link rel="preload" crossorigin="anonymous" href="/assets/NotoSansJP-Regular.woff" as="font" type="font/woff" />
-    <link rel="preload" crossorigin="anonymous" href="/assets/NotoSansJP-SemiBold.woff" as="font" type="font/woff" />
-    <link rel="preload" crossorigin="anonymous" href="/assets/NotoSansJP-Thin.woff" as="font" type="font/woff" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet" />
     <link as="image" crossorigin="anonymous" href="/assets/cyber-toon.svg" rel="preload" />
     <script id="inject-data" type="application/json"></script>
     <script type="text/javascript" src="/client.global.js" defer></script>


### PR DESCRIPTION
- https://github.com/leonard475192/web-speed-hackathon-2024/issues/12

## 補足

### レギュレーションテスト

```
  1) [Mobile Chrome] › client/footer.spec.ts:56:11 › 作品ページ のフッター › 利用規約をクリックすると、モーダルで内容が表示されること ────

    Test timeout of 120000ms exceeded.

    Error: locator.textContent: Test timeout of 120000ms exceeded.
    Call log:
      - waiting for getByRole('dialog', { name: '利用規約' }).getByRole('paragraph')


      63 |         await expect(modal).toBeVisible();
      64 |         await expect(modal.getByRole('paragraph')).toContainText(/(青空文庫|クリエイティブ・コモンズ)/);
    > 65 |         const content = await modal.getByRole('paragraph').textContent();
         |                                                            ^
      66 |         expect(getSHA256Hash(content)).resolves.toBe(hash);
      67 |       });
      68 |     }

        at /Users/uchiuzo/Private/web-speed-hackathon-2024/workspaces/testing/src/client/footer.spec.ts:65:60

  2) [Mobile Chrome] › client/footer.spec.ts:56:11 › エピソードページ のフッター › 利用規約をクリックすると、モーダルで内容が表示されること ─

    Test timeout of 120000ms exceeded.

    Error: locator.textContent: Test timeout of 120000ms exceeded.
    Call log:
      - waiting for getByRole('dialog', { name: '利用規約' }).getByRole('paragraph')


      63 |         await expect(modal).toBeVisible();
      64 |         await expect(modal.getByRole('paragraph')).toContainText(/(青空文庫|クリエイティブ・コモンズ)/);
    > 65 |         const content = await modal.getByRole('paragraph').textContent();
         |                                                            ^
      66 |         expect(getSHA256Hash(content)).resolves.toBe(hash);
      67 |       });
      68 |     }

        at /Users/uchiuzo/Private/web-speed-hackathon-2024/workspaces/testing/src/client/footer.spec.ts:65:60

  2 failed
    [Mobile Chrome] › client/footer.spec.ts:56:11 › 作品ページ のフッター › 利用規約をクリックすると、モーダルで内容が表示されること ─────
    [Mobile Chrome] › client/footer.spec.ts:56:11 › エピソードページ のフッター › 利用規約をクリックすると、モーダルで内容が表示されること ──
  75 passed (3.0m)
 ELIFECYCLE  Command failed with exit code 1.
ERROR: "start:client" exited with 1.
/Users/uchiuzo/Private/web-speed-hackathon-2024/workspaces/testing:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @wsh-2024/testing@ start: `run-s start:client start:admin`
Exit status 1
 ELIFECYCLE  Test failed. See above for more details.
```

### 差分

```
        modified:   workspaces/testing/src/client/episode.spec.ts-snapshots/vrt-episode-Mobile-Chrome-darwin.png
        modified:   workspaces/testing/src/client/search.spec.ts-snapshots/vrt-search-result-Mobile-Chrome-darwin.png
        modified:   workspaces/testing/src/client/top.spec.ts-snapshots/vrt-today-updates-card-Mobile-Chrome-darwin.png
```

