### PR TITLE
Revert "chore: NODE_ENVの設定"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apk --no-cache add tzdata && \
 
 RUN apk --no-cache add jemalloc
 ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
-ENV NODE_ENV=production
 
 COPY . .
 RUN corepack enable pnpm


### PR DESCRIPTION
Reverts leonard475192/web-speed-hackathon-2024#22

- https://zenn.dev/cykinso/articles/3c7d590ca1dab1

```
> tsup
1.277 workspaces/client build: node:internal/modules/cjs/loader:1147
1.278 workspaces/client build:   throw err;
1.278 workspaces/client build:   ^
1.279 workspaces/client build: Error: Cannot find module '/usr/src/app/workspaces/client/node_modules/tsup/dist/cli-default.js'
1.279 workspaces/client build:     at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
1.279 workspaces/client build:     at Module._load (node:internal/modules/cjs/loader:985:27)
1.279 workspaces/client build:     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
1.279 workspaces/client build:     at node:internal/main/run_main_module:28:49 {
1.279 workspaces/client build:   code: 'MODULE_NOT_FOUND',
1.279 workspaces/client build:   requireStack: []
1.279 workspaces/client build: }
1.280 workspaces/client build: Node.js v20.11.1
1.280 workspaces/server build: node:internal/modules/cjs/loader:1147
1.280 workspaces/server build:   throw err;
1.280 workspaces/server build:   ^
1.280 workspaces/server build: Error: Cannot find module '/usr/src/app/workspaces/server/node_modules/tsup/dist/cli-default.js'
1.280 workspaces/server build:     at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
1.280 workspaces/server build:     at Module._load (node:internal/modules/cjs/loader:985:27)
1.280 workspaces/server build:     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
1.281 workspaces/server build:     at node:internal/main/run_main_module:28:49 {
1.281 workspaces/server build:   code: 'MODULE_NOT_FOUND',
1.281 workspaces/server build:   requireStack: []
1.281 workspaces/server build: }
1.281 workspaces/server build: Node.js v20.11.1
1.282 workspaces/client build:  ELIFECYCLE  Command failed with exit code 1.
1.283 workspaces/server build:  ELIFECYCLE  Command failed with exit code 1.
1.296 workspaces/client build: Failed
```